### PR TITLE
signatures += delroth

### DIFF
--- a/signatures/delroth.txt
+++ b/signatures/delroth.txt
@@ -1,0 +1,1 @@
+Pierre Bourdon (@delroth)


### PR DESCRIPTION
I am adding *myself* as a signatory, and I have:

 - Added a file under `signatures`
    - Named afted my GitHub handle (`@delroth`)
    - Containing the line of text to show as a signature
 - The commit message contains only my GitHub handle (`delroth`)