### PR TITLE
signature: add drupol

### DIFF
--- a/signatures/drupol.txt
+++ b/signatures/drupol.txt
@@ -1,0 +1,1 @@
+Pol Dellaiera (@drupol)


### PR DESCRIPTION
I am adding *myself* as a signatory, and I have:

 - Added a file under `signatures`
    - Named afted my GitHub handle (`@githubHandle`)
    - Containing the line of text to show as a signature
 - The commit message contains only my GitHub handle (`githubHandle`)

The suggested format for signature is:

```txt
Some Name (@githubHandle)
```

Though don't feel obliged to use this exact format. As long as you feel it identifies yourself as the signatory, and is not meant to disrupt the letter formatting.
