### PR TITLE
signature: add cafkafk

### DIFF
--- a/signatures/cafkafk.txt
+++ b/signatures/cafkafk.txt
@@ -1,0 +1,1 @@
+Christina Sørensen (@cafkafk)


### PR DESCRIPTION
Signed-off-by: Christina Sørensen <christina@cafkafk.com>

I am adding *myself* as a signatory, and I have:

 - Added a file under `signatures`
    - Named afted my GitHub handle (`@githubHandle`)
    - Containing the line of text to show as a signature
 - The commit message contains only my GitHub handle (`githubHandle`)

The suggested format for signature is:

```txt
Some Name (@githubHandle)
```

Though don't feel obliged to use this exact format. As long as you feel it identifies yourself as the signatory, and is not meant to disrupt the letter formatting.
