### PR TITLE
Create pws1453

### DIFF
--- a/signatures/pws1453
+++ b/signatures/pws1453
@@ -1,0 +1,1 @@
+Gaia Sergent (@pws1453)


### PR DESCRIPTION
I am adding *myself* as a signatory, and I have:

 - Added a file under `signatures`
    - Named after my GitHub handle (`@pws1453`)
    - Containing the line of text to show as a signature
 - The commit message contains only my GitHub handle (`pws1453`)
