### PR TITLE
adding myself

### DIFF
--- a/signatures/casuallyblue
+++ b/signatures/casuallyblue
@@ -1,0 +1,1 @@
+Sierra (@casuallyblue)


### PR DESCRIPTION
I am adding *myself* as a signatory, and I have:

 - Added a file under `signatures`
    - Named after my GitHub handle (`@casuallyblue`)
    - Containing the line of text to show as a signature
 - The commit message contains only my GitHub handle (`casuallyblue`)
