### PR TITLE
Sign open letter @totoroot

### DIFF
--- a/signatures/totoroot
+++ b/signatures/totoroot
@@ -1,0 +1,1 @@
+Matthias Thym (@totoroot)


### PR DESCRIPTION
I am adding *myself* as a signatory, and I have:

 - Added a file under `signatures`
    - Named after my GitHub handle (`@totoroot`)
    - Containing the line of text to show as a signature
 - The commit message contains only my GitHub handle (`@totoroot`)

---

I wouldn't want to see a community I've been apart of for years, be associated with something I strongly oppose.

I was vocally advocating against a military company sponsoring NixCon 2023 in Darmstadt, as even I, as an admittedly quite privileged person, already felt uncomfortable with their presence. I would not wish for less privileged people or members of certain minority groups to stay away from community events going forward, because of endorsements of companies whose actions might endanger them in the future or already do so now.

I understand that the Nix Foundation needs funding, not only for events like this, but I see accepting sponsorships from the Military Industrial Complex as something that will only cause damage to the Nix community as a whole in the long term. Not only in terms of reputation but also in term of money as I think it is very likely that accepting those questionable sponsorships could scare off other, reputable sponsors.
