### PR TITLE
Add signature for @camtauxe

### DIFF
--- a/signatures/camtauxe
+++ b/signatures/camtauxe
@@ -1,0 +1,1 @@
+camtauxe (@camtauxe)


### PR DESCRIPTION
I am adding *myself* as a signatory, and I have:

 - Added a file under `signatures`
    - Named after my GitHub handle (`@githubHandle`)
    - Containing the line of text to show as a signature
 - The commit message contains only my GitHub handle (`githubHandle`)