### PR TITLE
dotlambda

### DIFF
--- a/signatures/dotlambda
+++ b/signatures/dotlambda
@@ -1,0 +1,1 @@
+Robert Schütz (@dotlambda)


### PR DESCRIPTION
I am adding *myself* as a signatory, and I have:

 - Added a file under `signatures`
    - Named after my GitHub handle (`@dotlambda`)
    - Containing the line of text to show as a signature
 - The commit message contains only my GitHub handle (`dotlambda`)
